### PR TITLE
#4 making Python 3 map() iterables serializable to JSON

### DIFF
--- a/graphcommons.py
+++ b/graphcommons.py
@@ -107,7 +107,7 @@ class Graph(Entity):
         return self._node_types.get(node_type_id, None)
 
     def edges_for(self, node, direction):
-        if isinstance(node, basestring):
+        if isinstance(node, str):
             node = self.get_node(node)
 
         return [edge for edge in self.edges


### PR DESCRIPTION
In Python 3, `map()` returns an iterator rather than a list:
https://docs.python.org/3.0/whatsnew/3.0.html#views-and-iterators-instead-of-lists

I opted for the quick fix to cast to a `list()`.