### PR TITLE
#8 commenting out deprecated Python 2 unicode() call

### DIFF
--- a/graphcommons.py
+++ b/graphcommons.py
@@ -107,7 +107,7 @@ class Graph(Entity):
         return self._node_types.get(node_type_id, None)
 
     def edges_for(self, node, direction):
-        if isinstance(node, basestring):
+        if isinstance(node, str):
             node = self.get_node(node)
 
         return [edge for edge in self.edges


### PR DESCRIPTION
In order to expedite usage within a Python 3 environment, just commenting out this call.