### PR TITLE
#4: casting map() calls to lists

### DIFF
--- a/graphcommons.py
+++ b/graphcommons.py
@@ -180,13 +180,13 @@ class GraphCommons(object):
 
     def new_graph(self, signals=None, **kwargs):
         if signals is not None:
-            kwargs['signals'] = map(dict, signals)
+            kwargs['signals'] = list(map(dict, signals))
         response = self.make_request('post', 'graphs', data=kwargs)
         return Graph(**response.json()['graph'])
 
     def update_graph(self, id, signals=None, **kwargs):
         if signals is not None:
-            kwargs['signals'] = map(dict, signals)
+            kwargs['signals'] = list(map(dict, signals))
         endpoint = 'graphs/%s/add' % id
         response = self.make_request('put', endpoint, data=kwargs)
         return Graph(**response.json()['graph'])


### PR DESCRIPTION
Python 3 `map()` returns an iterator rather than a list.  Taking the easy route of casting the existing calls to `list()`s.
https://docs.python.org/3.0/whatsnew/3.0.html#views-and-iterators-instead-of-lists