### PR TITLE
#8: commenting out Python 2 unicode() call for now

### DIFF
--- a/graphcommons.py
+++ b/graphcommons.py
@@ -124,8 +124,8 @@ class GraphCommonsException(Exception):
     def __init__(self, status_code, message):
         self.status_code = status_code
 
-        if isinstance(message, unicode):
-            message = message.encode("utf-8")  # Otherwise, it will not be printed.
+        # if isinstance(message, unicode):
+        #     message = message.encode("utf-8")  # Otherwise, it will not be printed.
 
         self.message = message
 


### PR DESCRIPTION
The `unicode()` function is deprecated in Python 3; commenting out the code using it for now.