### PR TITLE
UserDict implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ pip install graphcommons
 ### Get graph
 ```python
 graph = graphcommons.graphs('7141da86-2a40-4fdc-a7ac-031b434b9653')
-print(graph.name)  # Hello from python
+print(graph['name'])  # Hello from python
 
 for node in graph.nodes:
-    print(node.name)
+    print(node['name'])
 
     print(graph.edges_from(node))  # edges directed from the node
     print(graph.edges_to(node))  # edges directed to the node
@@ -60,7 +60,7 @@ graph = graphcommons.new_graph(
 )
 
 
-print(graph.id)  # added graph's id
+print(graph['id'])  # added graph's id
 ```
 
 ### Update Graph

--- a/graphcommons.py
+++ b/graphcommons.py
@@ -1,31 +1,22 @@
+from collections import UserDict
 from requests.api import request
 from itertools import chain
 
 
-def extend(base, name=None, **kwargs):
-    return type(name, (base,), kwargs)
+class Entity(UserDict):
+    """Base class for all objects."""
 
 
-class Entity(dict):
-    __getattr__ = dict.get
-
-    def __repr__(self):
-        printable = self.name or self.id
-
-        if not printable:
-            return super(Entity, self).__repr__()
-
-        return '%s: %s' % (
-            self.__class__.__name__,
-            printable.encode("utf-8")
-        )
+class Signal(Entity):
+    """Represents a signal operation in the Graph Commons infrastructure."""
 
 
-Signal = extend(Entity, 'Signal')
-Path = extend(Entity, 'Path')
+class Path(Entity):
+    """Represents a path object in the Graph Commons infrastructure."""
 
 
 class Edge(Entity):
+    """Represents an edge object in the Graph Commons infrastructure."""
 
     def to_signal(self, action, graph):
         # signal types: create or update
@@ -47,6 +38,7 @@ class Edge(Entity):
 
 
 class Node(Entity):
+    """Represents a node object in the Graph Commons infrastructure."""
 
     def to_signal(self, action, graph):
         # signal types: create or update
@@ -64,6 +56,7 @@ class Node(Entity):
 
 
 class EdgeType(Entity):
+    """Represents an edge type object in the Graph Commons infrastructure."""
 
     def to_signal(self, action):
         action = "edgetype_%s" % action
@@ -74,6 +67,7 @@ class EdgeType(Entity):
 
 
 class NodeType(Entity):
+    """Represents a node type object in the Graph Commons infrastructure."""
 
     def to_signal(self, action):
         action = "nodetype_%s" % action

--- a/graphcommons.py
+++ b/graphcommons.py
@@ -26,14 +26,14 @@ class Edge(Entity):
         from_node = graph.get_node(from_id)
         to_node = graph.get_node(to_id)
         kwargs = dict(action=action,
-                      name=self.edge_type,
-                      from_name=from_node.name,
-                      from_type=from_node.type,
-                      to_name=to_node.name,
-                      to_type=to_node.type,
+                      name=self['edge_type'],
+                      from_name=from_node['name'],
+                      from_type=from_node['type'],
+                      to_name=to_node['name'],
+                      to_type=to_node['type'],
                       reference=self.get('reference', None),
                       weight=self.get('weight'),
-                      properties=self.properties)
+                      properties=self['properties'])
         return Signal(**kwargs)
 
 
@@ -44,14 +44,14 @@ class Node(Entity):
         # signal types: create or update
         action = "node_%s" % action
         kwargs = dict(action=action,
-                      name=self.name,
-                      type=self.type['name'],
-                      reference=self.reference,
-                      image=self.image,
-                      color=self.type['color'],
-                      url=self.url,
-                      description=self.description,
-                      properties=self.properties)
+                      name=self['name'],
+                      type=self['type']['name'],
+                      reference=self.get('reference', None),
+                      image=self.get('image', None),
+                      color=self['type']['color'],
+                      url=self.get('url', None),
+                      description=self['description'],
+                      properties=self['properties'])
         return Signal(**kwargs)
 
 
@@ -61,8 +61,9 @@ class EdgeType(Entity):
     def to_signal(self, action):
         action = "edgetype_%s" % action
         kwargs = dict(action=action)
-        kwargs.update(dict((k, self.get(k, None)) for k in ['name', 'color', 'name_alias', 'weighted',
-                                                            'properties', 'image_as_icon', 'image']))
+        keys = ['name', 'color', 'name_alias', 'weighted', 'properties',
+                'image_as_icon', 'image']
+        kwargs.update(dict((k, self.get(k, None)) for k in keys))
         return Signal(**kwargs)
 
 
@@ -72,24 +73,25 @@ class NodeType(Entity):
     def to_signal(self, action):
         action = "nodetype_%s" % action
         kwargs = dict(action=action)
-        kwargs.update(dict((k, self.get(k, None)) for k in ['name', 'color', 'name_alias', 'size_limit',
-                                                            'properties', 'image_as_icon', 'image', 'size']))
+        keys = ['name', 'color', 'name_alias', 'size_limit', 'properties',
+                'image_as_icon', 'image', 'size']
+        kwargs.update(dict((k, self.get(k, None)) for k in keys))
         return Signal(**kwargs)
 
 
 class Graph(Entity):
     def __init__(self, *args, **kwargs):
         super(Graph, self).__init__(*args, **kwargs)
-        self.edges = map(Edge, self.edges or [])
-        self.nodes = map(Node, self.nodes or [])
-        self.node_types = map(NodeType, self.nodeTypes or [])
-        self.edge_types = map(EdgeType, self.edgeTypes or [])
+        self.edges = list(map(Edge, self['edges'] or []))
+        self.nodes = list(map(Node, self['nodes'] or []))
+        self.node_types = list(map(NodeType, self['nodeTypes'] or []))
+        self.edge_types = list(map(EdgeType, self['edgeTypes'] or []))
 
         # hash for quick search
-        self._edges = dict((edge.id, edge) for edge in self.edges)
-        self._nodes = dict((node.id, node) for node in self.nodes)
-        self._node_types = dict((t.id, t) for t in self.node_types)
-        self._edge_types = dict((t.id, t) for t in self.edge_types)
+        self._edges = dict((edge['id'], edge) for edge in self.edges)
+        self._nodes = dict((node['id'], node) for node in self.nodes)
+        self._node_types = dict((t['id'], t) for t in self.node_types)
+        self._edge_types = dict((t['id'], t) for t in self.edge_types)
 
     def get_node(self, node_id):
         return self._nodes.get(node_id, None)
@@ -105,7 +107,7 @@ class Graph(Entity):
             node = self.get_node(node)
 
         return [edge for edge in self.edges
-                if edge[direction] == node.id]
+                if edge[direction] == node['id']]
 
     def edges_from(self, node):
         return self.edges_for(node, 'from')

--- a/graphcommons.py
+++ b/graphcommons.py
@@ -43,12 +43,13 @@ class Node(Entity):
     def to_signal(self, action, graph):
         # signal types: create or update
         action = "node_%s" % action
+        node_type = graph.get_node_type(self['type_id'])
         kwargs = dict(action=action,
                       name=self['name'],
-                      type=self['type']['name'],
+                      type=self['type'],
                       reference=self.get('reference', None),
                       image=self.get('image', None),
-                      color=self['type']['color'],
+                      color=node_type['color'],
                       url=self.get('url', None),
                       description=self['description'],
                       properties=self['properties'])


### PR DESCRIPTION
Hello,
Here's a minimal re-implementation of the GraphCommons Python API wrapper to get it up-to-speed for Python 3.  Here are the primary changes:

1. The base `Entity` class now derives from [`UserDict`](https://docs.python.org/3/library/collections.html#collections.UserDict) rather than `dict` because that appears to be a best practice for using the [MutableMapping abstract base class](https://docs.python.org/3/library/collections.abc.html#collections.abc.MutableMapping) without having to define concrete methods.
1. All of the API wrapper's Graph Commons objects derive from `Entity`, but references to attributes in the dictionary were made using object attribute notation with a little obscure magic.  These have been changed to dictionary references to make them more clear to other coders, and I removed the code in `Entity` that made that work.
1. Additional casts of the `map()` calls to `list()`s to make them work in Python 3 environments.
1. Removed the custom `extends()` function which was only used for `Signal` and `Path` class definitions, and formalized those class definitions.
1. And the `README.md` was updated to enable working examples using dictionary references.

I also added in some placeholder comments, but there's a ways to go.  And I haven't exercised all of the functions so there may be some additional errors to catch.  I'll update this [`userdict` branch](https://github.com/gregoryfoster/graphcommons-python/tree/userdict) with anything else that seems appropriate.  My [`dev` branch](https://github.com/gregoryfoster/graphcommons-python/tree/dev) incorporates all of the pull requests issued.

